### PR TITLE
chore: Add security policy, dependabot, CODEOWNERS, CI badge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Default owner for everything
+* @lyehe
+
+# Security-sensitive areas (require owner review)
+/porterminal/pty/           @lyehe
+/porterminal/infrastructure/ @lyehe
+/.github/workflows/         @lyehe
+/SECURITY.md                @lyehe
+
+# Frontend
+/frontend/                  @lyehe
+
+# Configuration
+pyproject.toml              @lyehe

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
+| < 0.2   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+### Private Disclosure (Preferred)
+
+Use [GitHub's private vulnerability reporting](https://github.com/lyehe/porterminal/security/advisories/new):
+
+1. Go to **Security** → **Advisories** → **New draft advisory**
+2. Fill in the vulnerability details
+3. Submit for review
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Potential impact
+- Any suggested fixes (optional)
+
+### Response Timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Initial assessment**: Within 7 days
+- **Resolution target**: Within 90 days (depending on severity)
+
+### Scope
+
+This policy applies to:
+- The `porterminal` Python package
+- The frontend TypeScript code
+- WebSocket communication
+- Cloudflare tunnel integration
+
+### Out of Scope
+
+- Vulnerabilities in Cloudflare's infrastructure
+- Issues in third-party dependencies (report to upstream)
+- Social engineering attacks
+
+## Security Considerations
+
+Porterminal exposes terminal access over the network. Users should:
+- Only run on trusted networks
+- Use the URL-based authentication token
+- Be aware that terminal output is transmitted over WebSocket

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+updates:
+  # Python dependencies (pip/uv)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      python-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+
+  # npm dependencies (frontend)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "javascript"
+    groups:
+      npm-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
   <a href="https://github.com/lyehe/porterminal/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/lyehe/porterminal?style=flat-square" alt="License">
   </a>
+  <a href="https://github.com/lyehe/porterminal/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/lyehe/porterminal/ci.yml?branch=master&style=flat-square&logo=github&label=CI" alt="CI">
+  </a>
 </p>
 
 


### PR DESCRIPTION
## Summary
- Add SECURITY.md with vulnerability disclosure policy (GitHub private reporting)
- Add dependabot.yml for automated dependency updates (pip, npm, actions)
- Add CODEOWNERS file (@lyehe as default owner)
- Add CI status badge to README

## Type
- [x] Documentation
- [x] New feature

## Post-Merge Action
Enable private vulnerability reporting:
**Settings → Security → Private vulnerability reporting → Enable**