### PR TITLE
ci: lock dependencies to security-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,21 @@
+# Dependabot is configured for SECURITY UPDATES ONLY.
+#
+# `open-pull-requests-limit: 0` disables routine *version* update PRs for each
+# ecosystem. Dependabot *security* updates (raised in response to security
+# advisories) are unaffected by this limit and continue to flow - they have a
+# separate, fixed cap of 10 open PRs.
+#
+# Net effect: we stay pinned to the exact versions in uv.lock and
+# frontend/package-lock.json, and Dependabot only opens a PR when a dependency
+# has a known vulnerability. No more surprise major bumps (e.g. TS 6 / Vite 8).
+#
+# REQUIRES (repo Settings -> Code security): "Dependabot alerts" AND
+# "Dependabot security updates" must both be enabled - this file alone does not
+# turn them on. Dependabot also reads this file from the DEFAULT branch
+# (master), so changes only take effect once merged to master.
 version: 2
 updates:
-  # Python dependencies (pip/uv)
+  # Python dependencies (pip/uv) - security updates only
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -11,16 +26,10 @@ updates:
     labels:
       - "dependencies"
       - "python"
-    groups:
-      python-minor:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 5
+      - "security"
+    open-pull-requests-limit: 0
 
-  # npm dependencies (frontend)
+  # npm dependencies (frontend) - security updates only
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
@@ -31,25 +40,10 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
-    groups:
-      npm-minor:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "@xterm/*"
-        update-types:
-          - "minor"
-          - "patch"
-      xterm:
-        patterns:
-          - "@xterm/*"
-        update-types:
-          - "major"
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 5
+      - "security"
+    open-pull-requests-limit: 0
 
-  # GitHub Actions
+  # GitHub Actions - security updates only
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -60,7 +54,5 @@ updates:
     labels:
       - "dependencies"
       - "ci"
-    groups:
-      actions:
-        patterns:
-          - "*"
+      - "security"
+    open-pull-requests-limit: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync
+        # --frozen (not --locked): hatch-vcs rewrites uv.lock's project version
+        # every commit, so --locked would fail on every build.
+        run: uv sync --frozen
 
       - name: Lint with ruff
         run: uv run ruff check .

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,7 +23,9 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        # --frozen (not --locked): hatch-vcs rewrites uv.lock's project version
+        # every commit, so --locked would fail on every build.
+        run: uv sync --frozen
 
       - name: Lint with ruff
         run: uv run ruff check .
@@ -57,7 +59,9 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        # --frozen (not --locked): hatch-vcs rewrites uv.lock's project version
+        # every commit, so --locked would fail on every build.
+        run: uv sync --frozen
 
       - name: Run tests
         run: uv run pytest


### PR DESCRIPTION
## What

Locks the project to stable, pinned dependency versions and stops surprise
major bumps (like the recent TypeScript 6 / Vite 8 upgrades).

### Dependabot → security updates only
- `open-pull-requests-limit: 0` on all three ecosystems (pip, npm,
  github-actions): disables routine **version** update PRs while leaving
  **security** updates (advisory-driven, separate fixed cap of 10) active.
- Removed the now-inert version-update `groups`.

### CI → install strictly from the lockfile
- `uv sync` → `uv sync --frozen` in `ci.yml` and `pr-checks.yml`.
- **`--frozen`, not `--locked`**: hatch-vcs rewrites `uv.lock`'s project
  version on every commit, so `--locked` would fail on every build. Verified
  empirically (`--frozen` exits 0, `--locked` exits 2 on this repo). `npm ci`
  is already strict on the frontend side.

## Required to fully take effect (handled separately)
- Dependabot **alerts + security updates** must be enabled in repo Settings →
  Code security (being enabled via API alongside this PR).
- Dependabot reads its config only from the **default branch**, so this policy
  is live once merged to `master`.

## Related
Supersedes the routine version-bump PRs #29 and #30, which are being closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
