### PR TITLE
feat: press 'c' to copy the connection URL to the clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ So I built something simpler: **run a command, scan a QR, start typing.**
 - **Full terminal apps** - vim, htop, less, tmux all work correctly with proper alt-screen buffer handling.
 - **Persistent multi-tab sessions** - Sessions survive disconnects. Close the browser, switch networks, reconnect from another device—your shell and running processes are still there. Multiple devices can view the same session simultaneously.
 - **Cross-platform** - Windows (PowerShell, CMD, WSL), Linux/macOS (Bash, Zsh, Fish, Nushell, and any shell via `$SHELL`). Auto-detects your shells.
+- **Private by default** - The secret tunnel URL never sits on screen, so it's safe to screen-share or screenshot the QR. Press `c` to copy the URL when you need it.
 
 ## Install
 
@@ -77,6 +78,8 @@ ptn ~/projects/myapp   # Start in specific folder
 | `-c, --compose` | Enable compose mode by default |
 | `-u, --check-update` | Check if a newer version is available |
 | `-V, --version` | Show version |
+
+**While running:** with a tunnel active, the connection URL is hidden on screen for privacy — press **`c`** to copy it to your clipboard, or scan the QR to connect. `Ctrl+C` stops the server.
 
 ## Mobile Gestures
 

--- a/porterminal/__init__.py
+++ b/porterminal/__init__.py
@@ -23,7 +23,12 @@ from threading import Event, Thread
 
 from rich.console import Console
 
-from porterminal.cli import display_startup_screen, parse_args
+from porterminal.cli import (
+    copy_to_clipboard,
+    display_startup_screen,
+    parse_args,
+    start_key_listener,
+)
 from porterminal.infrastructure import (
     CloudflaredInstaller,
     drain_process_output,
@@ -89,7 +94,10 @@ def _run_in_background(args) -> int:
                         is_tunnel = url.startswith("https://")
                         cwd = args.path or os.getcwd()
 
-                        # Display full startup screen with QR code
+                        # Background mode intentionally shows the URL in plaintext:
+                        # the parent exits right after this, so there is no persistent
+                        # display to protect and no key listener. The hidden-URL /
+                        # 'c'-to-copy flow is foreground-tunnel-only.
                         display_startup_screen(url, is_tunnel=is_tunnel, cwd=cwd)
 
                         # Add background mode info
@@ -287,6 +295,23 @@ def main() -> int:
     else:
         display_url = tunnel_url
 
+    # The copy-to-clipboard hotkey only makes sense for the secret tunnel URL on
+    # an interactive terminal. A localhost URL (--no-tunnel) has nothing to hide,
+    # and a background child (args.url_file) has no keyboard - in both cases the
+    # URL is shown normally and no key listener runs.
+    interactive = sys.stdin.isatty() and not args.url_file and not args.no_tunnel
+
+    def redraw(show_url: bool = True, status: str | None = None) -> None:
+        """Render the startup screen, keeping the invariant args in one place."""
+        display_startup_screen(
+            display_url,
+            is_tunnel=not args.no_tunnel,
+            cwd=display_cwd,
+            show_url=show_url,
+            copy_mode=interactive,
+            copy_status=status,
+        )
+
     # If running as background child, write URL to file and skip display
     if args.url_file:
         try:
@@ -295,13 +320,15 @@ def main() -> int:
             console.print(f"[red]Error writing URL file:[/red] {e}")
     else:
         # Display final screen (only in foreground mode)
-        display_startup_screen(display_url, is_tunnel=not args.no_tunnel, cwd=display_cwd)
+        redraw()
 
     # Use events for Ctrl+C handling and connection/visibility detection
     shutdown_event = Event()
     connected_event = Event()
     url_visibility_event = Event()  # Set when visibility should change
     url_visible = [True]  # Mutable container for visibility state
+    copy_event = Event()  # Set when the 'c' hotkey copies the URL
+    copy_feedback: list[str | None] = [None]  # Transient feedback line (mutable cell)
 
     def signal_handler(signum: int, frame: object) -> None:
         shutdown_event.set()
@@ -312,6 +339,17 @@ def main() -> int:
     def on_url_visibility(visible: bool) -> None:
         url_visible[0] = visible
         url_visibility_event.set()
+
+    def handle_copy() -> None:
+        # Runs on the key-listener thread. On failure, reveal the URL inline so
+        # it's still recoverable even though it's normally hidden.
+        if copy_to_clipboard(display_url):
+            copy_feedback[0] = "[green]✓ URL copied to clipboard[/green]"
+        else:
+            copy_feedback[0] = (
+                f"[yellow]⚠ Clipboard unavailable:[/yellow] [cyan]{display_url}[/cyan]"
+            )
+        copy_event.set()
 
     # Drain process output silently in background (only when not verbose)
     if server_process is not None and not verbose:
@@ -324,8 +362,14 @@ def main() -> int:
     if tunnel_process is not None:
         Thread(target=drain_process_output, args=(tunnel_process,), daemon=True).start()
 
-    # Track if QR hiding is disabled or already hidden
+    # Listen for the 'c' hotkey to copy the URL (foreground interactive only)
+    if interactive:
+        start_key_listener(shutdown_event, {"c": handle_copy})
+
+    # qr_hidden = "auto-hide-on-connect is disabled or already handled" - distinct
+    # from current_show_url, which tracks whether the QR is actually on screen now.
     qr_hidden = args.url_file is not None or args.keep_qr
+    current_show_url = True  # QR is visible after the initial display above
 
     old_handler = signal.signal(signal.SIGINT, signal_handler)
     try:
@@ -348,12 +392,8 @@ def main() -> int:
             # Handle URL visibility toggle from frontend (takes priority)
             if url_visibility_event.is_set():
                 url_visibility_event.clear()
-                display_startup_screen(
-                    display_url,
-                    is_tunnel=not args.no_tunnel,
-                    cwd=display_cwd,
-                    show_url=url_visible[0],
-                )
+                current_show_url = url_visible[0]
+                redraw(show_url=current_show_url)
                 qr_hidden = not url_visible[0]
                 if url_visible[0]:
                     # Clear connected_event so auto-hide doesn't trigger immediately
@@ -362,12 +402,13 @@ def main() -> int:
             # Hide QR code after first connection (unless --keep-qr)
             elif not qr_hidden and connected_event.is_set():
                 qr_hidden = True
-                display_startup_screen(
-                    display_url,
-                    is_tunnel=not args.no_tunnel,
-                    cwd=display_cwd,
-                    show_url=False,
-                )
+                current_show_url = False
+                redraw(show_url=False)
+
+            # Show transient feedback after the 'c' hotkey copies the URL
+            elif copy_event.is_set():
+                copy_event.clear()
+                redraw(show_url=current_show_url, status=copy_feedback[0])
 
             shutdown_event.wait(0.1)
     finally:

--- a/porterminal/__init__.py
+++ b/porterminal/__init__.py
@@ -328,7 +328,7 @@ def main() -> int:
     url_visibility_event = Event()  # Set when visibility should change
     url_visible = [True]  # Mutable container for visibility state
     copy_event = Event()  # Set when the 'c' hotkey copies the URL
-    copy_feedback: list[str | None] = [None]  # Transient feedback line (mutable cell)
+    copy_feedback: list[str | None] = [None]  # Feedback line, shown until next redraw
 
     def signal_handler(signum: int, frame: object) -> None:
         shutdown_event.set()
@@ -363,8 +363,9 @@ def main() -> int:
         Thread(target=drain_process_output, args=(tunnel_process,), daemon=True).start()
 
     # Listen for the 'c' hotkey to copy the URL (foreground interactive only)
-    if interactive:
-        start_key_listener(shutdown_event, {"c": handle_copy})
+    listener_thread = (
+        start_key_listener(shutdown_event, {"c": handle_copy}) if interactive else None
+    )
 
     # qr_hidden = "auto-hide-on-connect is disabled or already handled" - distinct
     # from current_show_url, which tracks whether the QR is actually on screen now.
@@ -416,6 +417,13 @@ def main() -> int:
 
     if shutdown_event.is_set():
         console.print("\n[dim]Shutting down...[/dim]")
+
+    # Stop the key listener and let it restore the terminal (cbreak) before we
+    # print or clean up. The loop may have exited via process death without
+    # shutdown_event set, so set it here to cover that path too.
+    shutdown_event.set()
+    if listener_thread is not None:
+        listener_thread.join(timeout=1)
 
     # Cleanup - terminate gracefully, then kill if needed
     def cleanup_process(proc: subprocess.Popen | None, name: str) -> None:

--- a/porterminal/cli/__init__.py
+++ b/porterminal/cli/__init__.py
@@ -1,6 +1,7 @@
 """CLI utilities for Porterminal."""
 
 from .args import parse_args
+from .clipboard import copy_to_clipboard
 from .display import (
     LOGO,
     TAGLINE_PORTABLE,
@@ -9,9 +10,12 @@ from .display import (
     display_startup_screen,
     get_qr_code,
 )
+from .keypress import start_key_listener
 
 __all__ = [
     "parse_args",
+    "copy_to_clipboard",
+    "start_key_listener",
     "display_connected_screen",
     "display_startup_screen",
     "get_qr_code",

--- a/porterminal/cli/clipboard.py
+++ b/porterminal/cli/clipboard.py
@@ -1,0 +1,58 @@
+"""Cross-platform clipboard copy using built-in OS tools (no extra dependency).
+
+Mirrors the project's "try the platform tool, fall through gracefully" approach
+(see CloudflaredInstaller). No third-party clipboard library is required.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+# Linux clipboard utilities, tried in order: Wayland first, then X11 variants.
+# None is guaranteed to be installed, so we try each and report failure if all miss.
+_LINUX_CLIPBOARD_COMMANDS: tuple[list[str], ...] = (
+    ["wl-copy"],
+    ["xclip", "-selection", "clipboard"],
+    ["xsel", "--clipboard", "--input"],
+)
+
+
+def _pipe_to(cmd: list[str], text: str) -> bool:
+    """Pipe ``text`` into a clipboard command's stdin. Return True on success."""
+    try:
+        subprocess.run(
+            cmd,
+            input=text,
+            text=True,
+            check=True,
+            capture_output=True,
+            timeout=3,
+        )
+        return True
+    except (OSError, subprocess.SubprocessError):
+        # FileNotFoundError (tool missing), non-zero exit, or timeout.
+        return False
+
+
+def copy_to_clipboard(text: str) -> bool:
+    """Copy ``text`` to the system clipboard using built-in OS utilities.
+
+    Platform tools used (no third-party dependency):
+    - Windows: ``clip``
+    - macOS:   ``pbcopy``
+    - Linux:   ``wl-copy`` -> ``xclip`` -> ``xsel`` (first one available)
+
+    Args:
+        text: The text to place on the clipboard.
+
+    Returns:
+        True if the text was copied; False if no clipboard tool was available or
+        the copy failed (e.g. a headless Linux box with no clipboard server).
+    """
+    if sys.platform == "win32":
+        return _pipe_to(["clip"], text)
+    if sys.platform == "darwin":
+        return _pipe_to(["pbcopy"], text)
+    # Linux / other Unix: try each tool until one succeeds.
+    return any(_pipe_to(cmd, text) for cmd in _LINUX_CLIPBOARD_COMMANDS)

--- a/porterminal/cli/display.py
+++ b/porterminal/cli/display.py
@@ -178,6 +178,8 @@ def display_startup_screen(
     is_tunnel: bool = True,
     cwd: str | None = None,
     show_url: bool = True,
+    copy_mode: bool = False,
+    copy_status: str | None = None,
 ) -> None:
     """Display the startup screen with QR code or spiral placeholder.
 
@@ -185,19 +187,31 @@ def display_startup_screen(
         url: Primary URL to display and encode in QR.
         is_tunnel: Whether tunnel mode is active.
         cwd: Current working directory to display.
-        show_url: If True, show URL and QR. If False, mask URL and show spiral.
+        show_url: If True, show the QR code. If False, mask it with a spiral.
+        copy_mode: If True, the plaintext URL is never printed; the URL line
+            shows a "press c to copy" hint instead (the user copies it with the
+            'c' hotkey). The QR still follows ``show_url``.
+        copy_status: Optional transient line (e.g. copy confirmation) shown in
+            place of the copy hint. Only used when ``copy_mode`` is True.
     """
     console.clear()
 
-    # Build QR code or spiral placeholder
+    # Build QR code or spiral placeholder (depends only on show_url).
     if show_url:
         try:
             right_panel = get_qr_code(url)
         except Exception:
             right_panel = "[QR code unavailable]"
-        display_url = f"[bold cyan]{url}[/bold cyan]"
     else:
         right_panel = get_qr_placeholder(url)
+
+    # URL line. In copy mode the plaintext URL is never shown - the user copies
+    # it with the 'c' hotkey - so the line is a hint or transient feedback.
+    if copy_mode:
+        display_url = copy_status or "[dim]Press 'c' to copy URL[/dim]"
+    elif show_url:
+        display_url = f"[bold cyan]{url}[/bold cyan]"
+    else:
         display_url = "[dim]Show URL via Settings (top right)[/dim]"
 
     # Status indicator

--- a/porterminal/cli/display.py
+++ b/porterminal/cli/display.py
@@ -191,8 +191,9 @@ def display_startup_screen(
         copy_mode: If True, the plaintext URL is never printed; the URL line
             shows a "press c to copy" hint instead (the user copies it with the
             'c' hotkey). The QR still follows ``show_url``.
-        copy_status: Optional transient line (e.g. copy confirmation) shown in
-            place of the copy hint. Only used when ``copy_mode`` is True.
+        copy_status: Optional line (e.g. a copy confirmation) shown in place of
+            the default hint, until the next redraw. Only used when ``copy_mode``
+            is True.
     """
     console.clear()
 

--- a/porterminal/cli/keypress.py
+++ b/porterminal/cli/keypress.py
@@ -1,0 +1,98 @@
+"""Cross-platform single-keypress listener for interactive hotkeys.
+
+Runs a background daemon thread that reads one key at a time (no Enter needed)
+from the controlling terminal and dispatches it to handler callbacks. Designed
+to run alongside the blocking server loop in ``porterminal.main``.
+
+The CLI process is synchronous (uvicorn runs in a separate subprocess), so a
+daemon thread - matching the existing ``drain_process_output`` threads - is the
+right tool; there is no asyncio loop to integrate with.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from threading import Event, Thread
+
+Handlers = dict[str, Callable[[], None]]
+
+
+def start_key_listener(shutdown_event: Event, handlers: Handlers) -> None:
+    """Start a daemon thread dispatching single keypresses to ``handlers``.
+
+    Keys are matched case-insensitively, so ``{"c": ...}`` also fires on "C".
+    The thread stops when ``shutdown_event`` is set. It is a no-op when stdin is
+    not an interactive terminal (piped, redirected, or detached/background).
+
+    Args:
+        shutdown_event: Setting this stops the listener loop.
+        handlers: Map of lowercase key char -> zero-arg callback.
+    """
+    if not sys.stdin.isatty():
+        return
+
+    target = _listen_windows if sys.platform == "win32" else _listen_unix
+    Thread(target=target, args=(shutdown_event, handlers), daemon=True).start()
+
+
+def _dispatch(ch: str, handlers: Handlers) -> None:
+    handler = handlers.get(ch.lower())
+    if handler is None:
+        return
+    try:
+        handler()
+    except Exception:
+        # A misbehaving handler must never kill the listener thread.
+        pass
+
+
+def _listen_windows(shutdown_event: Event, handlers: Handlers) -> None:
+    import msvcrt
+    import time
+
+    while not shutdown_event.is_set():
+        if msvcrt.kbhit():
+            try:
+                ch = msvcrt.getwch()
+            except (OSError, ValueError):
+                continue
+            _dispatch(ch, handlers)
+        else:
+            time.sleep(0.05)
+
+
+def _listen_unix(shutdown_event: Event, handlers: Handlers) -> None:
+    import atexit
+    import select
+    import termios
+    import tty
+
+    fd = sys.stdin.fileno()
+    try:
+        old_settings = termios.tcgetattr(fd)
+    except termios.error:
+        return  # Not a real terminal; nothing to restore or read.
+
+    def restore() -> None:
+        try:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        except (termios.error, OSError):
+            pass
+
+    # Backstop: daemon threads are killed abruptly at interpreter exit and may
+    # skip the finally below, which would leave the terminal in cbreak mode.
+    atexit.register(restore)
+
+    try:
+        # cbreak (not raw): single-key reads with no echo, while Ctrl+C still
+        # raises SIGINT and output newline translation stays intact for redraws.
+        tty.setcbreak(fd)
+        while not shutdown_event.is_set():
+            ready, _, _ = select.select([sys.stdin], [], [], 0.2)
+            if ready:
+                ch = sys.stdin.read(1)
+                if ch:
+                    _dispatch(ch, handlers)
+    finally:
+        restore()

--- a/porterminal/cli/keypress.py
+++ b/porterminal/cli/keypress.py
@@ -18,22 +18,29 @@ from threading import Event, Thread
 Handlers = dict[str, Callable[[], None]]
 
 
-def start_key_listener(shutdown_event: Event, handlers: Handlers) -> None:
+def start_key_listener(shutdown_event: Event, handlers: Handlers) -> Thread | None:
     """Start a daemon thread dispatching single keypresses to ``handlers``.
 
     Keys are matched case-insensitively, so ``{"c": ...}`` also fires on "C".
-    The thread stops when ``shutdown_event`` is set. It is a no-op when stdin is
-    not an interactive terminal (piped, redirected, or detached/background).
+    The thread stops when ``shutdown_event`` is set; the caller should set it and
+    ``join()`` the returned thread on shutdown so the terminal is restored before
+    any further output. It is a no-op (returns None) when stdin is not an
+    interactive terminal (piped, redirected, or detached/background).
 
     Args:
         shutdown_event: Setting this stops the listener loop.
         handlers: Map of lowercase key char -> zero-arg callback.
+
+    Returns:
+        The listener thread, or None if stdin is not a TTY.
     """
     if not sys.stdin.isatty():
-        return
+        return None
 
     target = _listen_windows if sys.platform == "win32" else _listen_unix
-    Thread(target=target, args=(shutdown_event, handlers), daemon=True).start()
+    thread = Thread(target=target, args=(shutdown_event, handlers), daemon=True)
+    thread.start()
+    return thread
 
 
 def _dispatch(ch: str, handlers: Handlers) -> None:
@@ -64,6 +71,7 @@ def _listen_windows(shutdown_event: Event, handlers: Handlers) -> None:
 
 def _listen_unix(shutdown_event: Event, handlers: Handlers) -> None:
     import atexit
+    import os
     import select
     import termios
     import tty
@@ -89,9 +97,11 @@ def _listen_unix(shutdown_event: Event, handlers: Handlers) -> None:
         # raises SIGINT and output newline translation stays intact for redraws.
         tty.setcbreak(fd)
         while not shutdown_event.is_set():
-            ready, _, _ = select.select([sys.stdin], [], [], 0.2)
+            ready, _, _ = select.select([fd], [], [], 0.2)
             if ready:
-                ch = sys.stdin.read(1)
+                # Read the raw fd, not the buffered sys.stdin TextIOWrapper, so a
+                # byte can't sit in Python's buffer unseen by the next select().
+                ch = os.read(fd, 1).decode(errors="ignore")
                 if ch:
                     _dispatch(ch, handlers)
     finally:

--- a/tests/cli/test_clipboard.py
+++ b/tests/cli/test_clipboard.py
@@ -1,0 +1,87 @@
+"""Tests for the cross-platform clipboard helper."""
+
+import subprocess
+
+from porterminal.cli import clipboard
+from porterminal.cli.clipboard import copy_to_clipboard
+
+
+class TestCopyToClipboard:
+    """Tests for copy_to_clipboard platform dispatch and graceful failure."""
+
+    def test_windows_uses_clip(self, monkeypatch):
+        """Windows pipes the text into `clip`."""
+        monkeypatch.setattr(clipboard.sys, "platform", "win32")
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs.get("input")))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(clipboard.subprocess, "run", fake_run)
+
+        assert copy_to_clipboard("https://example.com") is True
+        assert calls == [(["clip"], "https://example.com")]
+
+    def test_macos_uses_pbcopy(self, monkeypatch):
+        """macOS pipes the text into `pbcopy`."""
+        monkeypatch.setattr(clipboard.sys, "platform", "darwin")
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(clipboard.subprocess, "run", fake_run)
+
+        assert copy_to_clipboard("text") is True
+        assert calls == [["pbcopy"]]
+
+    def test_linux_tries_tools_in_order_until_success(self, monkeypatch):
+        """Linux tries wl-copy, then xclip, then xsel, stopping at first success."""
+        monkeypatch.setattr(clipboard.sys, "platform", "linux")
+        attempted = []
+
+        def fake_run(cmd, **kwargs):
+            attempted.append(cmd[0])
+            if cmd[0] in ("wl-copy", "xclip"):
+                raise FileNotFoundError(cmd[0])
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(clipboard.subprocess, "run", fake_run)
+
+        assert copy_to_clipboard("text") is True
+        assert attempted == ["wl-copy", "xclip", "xsel"]
+
+    def test_linux_returns_false_when_no_tool_available(self, monkeypatch):
+        """Linux returns False when none of the clipboard tools exist."""
+        monkeypatch.setattr(clipboard.sys, "platform", "linux")
+
+        def fake_run(cmd, **kwargs):
+            raise FileNotFoundError(cmd[0])
+
+        monkeypatch.setattr(clipboard.subprocess, "run", fake_run)
+
+        assert copy_to_clipboard("text") is False
+
+    def test_returns_false_on_command_failure(self, monkeypatch):
+        """A non-zero exit (CalledProcessError) is reported as failure, not raised."""
+        monkeypatch.setattr(clipboard.sys, "platform", "darwin")
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr(clipboard.subprocess, "run", fake_run)
+
+        assert copy_to_clipboard("text") is False
+
+    def test_returns_false_on_timeout(self, monkeypatch):
+        """A timeout is reported as failure, not raised."""
+        monkeypatch.setattr(clipboard.sys, "platform", "win32")
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 3)
+
+        monkeypatch.setattr(clipboard.subprocess, "run", fake_run)
+
+        assert copy_to_clipboard("text") is False

--- a/tests/cli/test_display.py
+++ b/tests/cli/test_display.py
@@ -1,0 +1,39 @@
+"""Tests for copy-mode rendering in the startup screen (the privacy invariant)."""
+
+from porterminal.cli import display
+
+# A distinctive, short token that won't wrap; if the URL leaked, it would appear.
+_URL = "https://abcxyz123.example.com"
+_TOKEN = "abcxyz123"
+
+
+def _render(**kwargs) -> str:
+    with display.console.capture() as cap:
+        display.display_startup_screen(_URL, **kwargs)
+    return cap.get()
+
+
+class TestCopyModeRendering:
+    """In copy mode the plaintext URL must never be printed."""
+
+    def test_copy_mode_hides_url_and_shows_hint(self):
+        """copy_mode hides the URL and shows the 'press c to copy' hint."""
+        out = _render(copy_mode=True)
+        assert _TOKEN not in out
+        assert "copy URL" in out
+
+    def test_without_copy_mode_shows_url(self):
+        """Default (background / non-interactive) still prints the URL."""
+        out = _render(copy_mode=False)
+        assert _TOKEN in out
+
+    def test_copy_status_replaces_hint_and_still_hides_url(self):
+        """A copy_status line replaces the hint without revealing the URL."""
+        out = _render(copy_mode=True, copy_status="COPIED-OK")
+        assert "COPIED-OK" in out
+        assert _TOKEN not in out
+
+    def test_copy_mode_hides_url_even_when_qr_is_hidden(self):
+        """Hiding the QR (post-connect) must not fall back to printing the URL."""
+        out = _render(copy_mode=True, show_url=False)
+        assert _TOKEN not in out

--- a/tests/cli/test_keypress.py
+++ b/tests/cli/test_keypress.py
@@ -1,0 +1,81 @@
+"""Tests for the cross-platform key listener."""
+
+from threading import Event
+
+from porterminal.cli import keypress
+from porterminal.cli.keypress import _dispatch, start_key_listener
+
+
+class _FakeStdin:
+    """Minimal stdin stub exposing only isatty()."""
+
+    def __init__(self, tty: bool):
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+class _FakeThread:
+    """Records whether start() was called instead of spawning a real thread."""
+
+    def __init__(self, log: list):
+        self._log = log
+
+    def start(self) -> None:
+        self._log.append("started")
+
+
+class TestDispatch:
+    """Tests for key-to-handler dispatch."""
+
+    def test_calls_matching_handler(self):
+        """The handler mapped to the pressed key is invoked."""
+        called = []
+        _dispatch("c", {"c": lambda: called.append(True)})
+        assert called == [True]
+
+    def test_is_case_insensitive(self):
+        """Uppercase input matches a lowercase handler key."""
+        called = []
+        _dispatch("C", {"c": lambda: called.append(True)})
+        assert called == [True]
+
+    def test_ignores_unmapped_key(self):
+        """A key with no handler does nothing."""
+        called = []
+        _dispatch("x", {"c": lambda: called.append(True)})
+        assert called == []
+
+    def test_swallows_handler_exceptions(self):
+        """A raising handler must not propagate out of the listener loop."""
+
+        def boom():
+            raise RuntimeError("boom")
+
+        # Should not raise.
+        _dispatch("c", {"c": boom})
+
+
+class TestStartKeyListener:
+    """Tests for listener startup guards."""
+
+    def test_noop_when_not_a_tty(self, monkeypatch):
+        """No thread is spawned when stdin is not an interactive terminal."""
+        monkeypatch.setattr(keypress.sys, "stdin", _FakeStdin(tty=False))
+        started: list = []
+        monkeypatch.setattr(keypress, "Thread", lambda *a, **k: _FakeThread(started))
+
+        start_key_listener(Event(), {"c": lambda: None})
+
+        assert started == []
+
+    def test_starts_thread_when_tty(self, monkeypatch):
+        """A daemon thread is spawned when stdin is a terminal."""
+        monkeypatch.setattr(keypress.sys, "stdin", _FakeStdin(tty=True))
+        started: list = []
+        monkeypatch.setattr(keypress, "Thread", lambda *a, **k: _FakeThread(started))
+
+        start_key_listener(Event(), {"c": lambda: None})
+
+        assert started == ["started"]

--- a/tests/cli/test_keypress.py
+++ b/tests/cli/test_keypress.py
@@ -61,21 +61,23 @@ class TestStartKeyListener:
     """Tests for listener startup guards."""
 
     def test_noop_when_not_a_tty(self, monkeypatch):
-        """No thread is spawned when stdin is not an interactive terminal."""
+        """No thread is spawned and None is returned when stdin is not a TTY."""
         monkeypatch.setattr(keypress.sys, "stdin", _FakeStdin(tty=False))
         started: list = []
         monkeypatch.setattr(keypress, "Thread", lambda *a, **k: _FakeThread(started))
 
-        start_key_listener(Event(), {"c": lambda: None})
+        result = start_key_listener(Event(), {"c": lambda: None})
 
         assert started == []
+        assert result is None
 
     def test_starts_thread_when_tty(self, monkeypatch):
-        """A daemon thread is spawned when stdin is a terminal."""
+        """A daemon thread is spawned and returned when stdin is a terminal."""
         monkeypatch.setattr(keypress.sys, "stdin", _FakeStdin(tty=True))
         started: list = []
         monkeypatch.setattr(keypress, "Thread", lambda *a, **k: _FakeThread(started))
 
-        start_key_listener(Event(), {"c": lambda: None})
+        result = start_key_listener(Event(), {"c": lambda: None})
 
         assert started == ["started"]
+        assert result is not None


### PR DESCRIPTION
## What

Press **`c`** while `ptn` runs (foreground + tunnel) to copy the connection URL
to the clipboard. The plaintext URL is **hidden by default** — only the QR
shows — so the secret link is safe in screenshots / screen-shares. The URL line
shows `Press 'c' to copy URL`; pressing it flashes `✓ URL copied`.

## Design
- **No new dependency** — clipboard via OS tools (`clip` / `pbcopy` /
  `wl-copy`→`xclip`→`xsel`); on failure the URL is revealed inline so it stays
  recoverable.
- **Daemon thread**, not asyncio — the CLI is synchronous (uvicorn runs in a
  subprocess), matching the existing `drain_process_output` pattern.
- **Unix `cbreak`** (not raw) preserves `Ctrl+C` and output rendering. The
  listener is stopped + `join()`ed on shutdown, with an `atexit` backstop, so
  the terminal is always restored.
- **Scoped to foreground + tunnel + TTY** — `--no-tunnel` (localhost, no
  secret) and `-b` background keep showing the URL.

## Review
Ran a max-effort multi-angle review. Fixes applied: the key listener is now
stopped on **all** exit paths (previously it kept running after server/tunnel
death, holding the terminal in cbreak/no-echo until process exit); the Unix
reader uses raw `os.read(fd, 1)` to avoid a `select`-vs-buffered-`stdin`
mismatch; doc wording corrected; and a render-level test now locks in the
privacy invariant (plaintext URL never printed in copy mode).

## Tests
New: `tests/cli/test_clipboard.py`, `test_keypress.py`, `test_display.py`
(16 tests). Full suite: **250 passed / 27 skipped**, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
